### PR TITLE
[INFRA-2243] Switch to new buildPluginWithGradle() step in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,1 @@
-buildPlugin(
-  tests: [ skip: true ]
-)
+buildPluginWithGradle(tests: [skip: true])


### PR DESCRIPTION
There should be no difference in behaviour at the moment.
The existing buildPlugin() step is deprecated for Gradle-based plugins.
The new step is planned to get new Gradle/Groovy functionality over time.